### PR TITLE
verif: array-based RF checker, stop at ebreak, REF x0 writes

### DIFF
--- a/docs/EBREAK_MISMATCH_ANALYSIS.md
+++ b/docs/EBREAK_MISMATCH_ANALYSIS.md
@@ -1,0 +1,78 @@
+# Ebreak Mismatch Analysis: RTL vs Reference
+
+## Summary
+
+**Verdict: RTL bug.** The RTL is producing **duplicate register-file retirements** (the same instruction’s write is effectively retired more than once). The reference model’s control flow and RF write stream match the assembly; the RTL stream is the same at the start but then shifts and ends with 4 extra writes.
+
+---
+
+## Test Program (from `verif/rv_cpu/input.asm`)
+
+- **0x00–0x24**: I-type ALU (addi, slti, xori, ori, andi, …).
+- **0x38–0x8C**: Branches not taken (beq, bne), then Test 7 setup (addi x1=5, x2=10).
+- **0x98**: `beq x1, x1, beq_target` (taken).
+- **0x9C**: `addi x3, x0, 99` — **skipped** (branch taken).
+- **0xA0**: `addi x3, x0, 3` — branch target; **writes x3 = 3**.
+- **0xA4**: `bne x1, x2, bne_target` (taken).
+- **0xA8**: `addi x4, x0, 99` — **skipped**.
+- **0xAC**: `addi x4, x0, 4` — branch target; **writes x4 = 4**.
+- Then blt/bge/bltu/bgeu taken branches, JAL, JALR, NOPs, loop (x20 0→5), ebreak.
+
+So by the time we pass the first few taken branches:
+
+- Correct sequence of **writes** includes exactly one for **0xA0** (x3=3) and one for **0xAC** (x4=4).
+
+---
+
+## What the Mismatch Dump Shows
+
+- **Index 34**
+  - **REF:** pc=**0xAC**, x4=4  → addi x4, x0, 4 (correct).
+  - **RTL:**  pc=**0xA0**, x3=3  → addi x3, x0, 3 (correct for 0xA0, but wrong *position*).
+
+So at the **35th** write:
+
+- REF’s 35th write is from **0xAC** (x4=4).
+- RTL’s 35th write is from **0xA0** (x3=3).
+
+So RTL’s 35th write is the instruction that REF already retired as its **34th** write. That implies the RTL has **one extra write** somewhere in the first 34 retirements.
+
+- **Index 35–36:** REF has 0xB8 then 0xC4; RTL has **0xAC** then **0xAC** again → RTL retires **0xAC** twice.
+- **Index 37–38:** RTL shows **0xB8** twice → duplicate retirement for 0xB8.
+- Similar duplicate-PC pattern continues; at the end we get **4 “RTL extra”** entries: (0x10C, x0), (0x110, x20, 0), (0x114, x21, 5), (0x118, x20, 1) — i.e. NOP + loop init + first loop iteration.
+
+So:
+
+1. **First 34 writes:** RTL has one extra retirement (so its stream is already shifted).
+2. **Middle section:** RTL repeatedly retires the same PC twice (0xAC, 0xB8, …).
+3. **End:** RTL has 4 more retirements than REF (59 vs 55); those 4 match a second pass through 0x10C–0x118.
+
+Conclusion: the RTL is **duplicating retirements** (same instruction’s RF write counted/retired more than once), not the REF.
+
+---
+
+## Who Is Correct?
+
+- **Reference:** One instruction per cycle; branches/JAL/JALR set `next_pc`; no speculation; RF write only when an instruction that writes a register is executed. Matches the assembly and RV32I semantics.
+- **RTL:** Same program and same memory; the **values** written (e.g. x3=3, x4=4) are correct when the **PC** is correct, but the **order and count** of retirements are wrong: duplicates and 4 extra writes.
+
+So the **reference is correct**; the **RTL is wrong**: it is committing/writing the same instruction more than once in several places.
+
+---
+
+## Likely RTL Causes (to fix)
+
+1. **Flush / bubble propagation**
+   - When `branch_taken_Q102H` (or jump) is high, `flush_Q101H` bubbles decode (Q101H). The instruction that was in Q101H (e.g. the “skipped” instruction after the branch) must **not** later write the RF. If a bubble is not applied consistently (e.g. only to decode but not to later stages), or if valid/control is not cleared all the way to WB, that instruction can still retire and cause a duplicate write.
+
+2. **Load-use hazard and Q103H**
+   - When `load_use_hazard` is true, `ctrl_Q102H_eff = 0` is sent into Q103H, so the **current** Q102H instruction is not advanced to Q103H; instead a bubble is. But Q103H is **overwritten** with that bubble, so the instruction that was **already in Q103H** is lost. That would cause **missing** retirements, not extra. So this is a separate bug; the **extra** retirements are more likely from flush/valid handling.
+
+3. **JALR target LSB**
+   - The REF clears LSB: `next_pc = (data_rd1 + imm_i) & 32'hFFFFFFFE`. The RTL comment in `rv_ctrl.sv` says “Need to mask LSB of target” for JALR, but `rv_if` uses `alu_out_Q102H` directly for next PC. If JALR target LSB is not masked, the RTL could jump to the wrong address once and re-execute a block (e.g. 0x10C–0x118), which would add exactly the kind of “4 extra” block we see. So JALR LSB masking in RTL is worth checking.
+
+**Recommended next steps:**
+
+- Trace **valid** and **reg_write_en** from decode through to WB on branch/jump cycles; ensure flushed instructions never reach WB with valid=1.
+- Add JALR LSB masking for the branch target (e.g. in EXE: `(rs1 + imm) & 32'hFFFFFFFE` for JALR) and use that for `next_pc` when JALR is taken.
+- Optionally fix load-use hazard so that on stall we **hold** Q103H instead of overwriting it with a bubble, to avoid losing the load’s write-back.

--- a/docs/RTL_FIXES_REVIEW.md
+++ b/docs/RTL_FIXES_REVIEW.md
@@ -1,0 +1,102 @@
+# RTL Fixes for Correct Behaviour (RF Write Match vs Reference)
+
+## Summary
+
+The RTL commits **5 extra** register-file writes vs the reference (57 vs 52): **1 duplicate** of the first instruction’s write and **4** commits that should have been flushed (post-branch/jump or end-of-program). Two root causes were found; fixes are below.
+
+---
+
+## Fix 1: Gate WB register write by `valid` (safety net)
+
+**File:** `source/cpu/rv_ctrl.sv`  
+**Location:** WB control outputs (~lines 377–382)
+
+**Issue:** Bubbles (flushed instructions) and any invalid control still drive `reg_write_en_Q104H` and `reg_dst_Q104H`. If a bubble ever carries stale control, or `valid` is wrong, the RTL can do an RF write when it should not.
+
+**Change:** Gate the WB register-write by `ctrl_Q104H.valid`:
+
+```systemverilog
+// Before:
+assign wb_ctrl.reg_write_en_Q104H  = ctrl_Q104H.reg_write_en;
+assign wb_ctrl.reg_dst_Q104H       = ctrl_Q104H.rd;
+
+// After:
+assign wb_ctrl.reg_write_en_Q104H  = ctrl_Q104H.reg_write_en && ctrl_Q104H.valid;
+assign wb_ctrl.reg_dst_Q104H       = ctrl_Q104H.rd;  // unchanged (don't write when !valid anyway)
+```
+
+So any slot that is not a valid retirement (e.g. bubble) never writes the RF. This fixes the **four extra commits** if they come from bubbles that still had `reg_write_en` set, and prevents future bugs from invalid control reaching WB.
+
+**Status:** This change is **already applied** in `source/cpu/rv_ctrl.sv`.
+
+---
+
+## Fix 2: Remove duplicate first instruction (instruction memory read latency)
+
+**File:** `source/common/rv_mem.sv` and/or `source/cpu/rv_mem_wrap.sv`
+
+**Issue:** In `rv_mem`, the read data is **registered**:
+
+```systemverilog
+`DFF(rd_data, pre_rd_data, clk)
+```
+
+So there is **one cycle of read latency**. The CPU uses `instruction_Q101H = i_mem.rd_data` (the registered output). As a result:
+
+- Cycle 0 (first after reset): `pc_Q100H = 0`, memory is addressed 0; `rd_data` still holds the value from the previous cycle (instr at 0 from reset).
+- Cycle 1: PC advances to 4, but `rd_data` still shows the instruction at 0 until the next posedge.
+
+So the **same instruction (at 0)** is decoded for **two consecutive cycles** and two copies enter the pipeline → the first instruction retires twice → **duplicate first RF write**.
+
+**Options (pick one):**
+
+### Option A – Combinatorial instruction read (recommended for IMEM)
+
+Use combinatorial read for the **instruction** port only, so the instruction is valid in the same cycle as the address:
+
+- Add a **second read port** to `rv_mem` that is purely combinatorial (e.g. `rd_data_comb` from `pre_rd_data`), or
+- In `rv_mem_wrap`, instantiate a small IMEM that uses only combinatorial read (e.g. `assign instruction_Q101H = pre_rd_data` and do not register it), or
+- Add a parameter to `rv_mem` to choose registered vs combinatorial read and use combinatorial for the instruction-memory instance.
+
+Then drive `instruction_Q101H` from that combinatorial path so decode sees the instruction for the **current** `pc_Q100H` in the same cycle. That removes the duplicate first instruction.
+
+### Option B – Align pipeline with 1-cycle IMEM latency
+
+Keep the registered read and treat IMEM as 1-cycle latency:
+
+- Do **not** advance PC until the corresponding instruction has been received (e.g. hold PC for one cycle after reset so the first request is 0 and the first **used** instruction is the one returned for 0).
+- Feed decode with a **registered** instruction that updates only when the pipeline is allowed to advance (e.g. when `ready_Q101H`), so each instruction is used exactly once.
+
+Option B requires careful handling of the first cycle(s) and possible extra bubbles; Option A is simpler for a single-cycle pipeline that expects “instruction in same cycle as PC”.
+
+---
+
+## Fix 3 (optional): Ensure `valid` is driven for SYSTEM/EBREAK
+
+**File:** `source/cpu/rv_ctrl.sv`  
+**Location:** SYSTEM opcode case (~277–281)
+
+**Issue:** ECALL/EBREAK are implemented as NOPs; `ctrl_Q101H` keeps defaults (`valid = 1'b1`, `reg_write_en = 1'b0`). So they retire as “valid” but don’t write. If the reference or environment expects ebreak to stop before extra retirements, consider setting `ctrl_Q101H.valid = 1'b0` for SYSTEM so they don’t count as valid retirements, or keep as-is if the reference and testbench already agree.
+
+---
+
+## Order of application
+
+1. **Fix 1** (gate WB by `valid`) – do first; low risk and prevents invalid commits.
+2. **Fix 2** (IMEM read latency / duplicate first instruction) – required to remove the duplicate first RF write and align with the reference.
+3. **Fix 3** – only if you need to match a specific ebreak/ecall retirement policy.
+
+After Fix 1 and Fix 2, the RTL should match the reference (same count and same rd/data sequence) for the current test program.
+
+---
+
+## Verification: x0 writes count as retirements
+
+**Files:** `verif/rv32i_ref/tb/rv32i_ref.sv`, `verif/rv32i_ref/tb/rv_cpu_checker.sv`
+
+Instructions that write to **x0** are real instructions: they retire and are committed; they simply do not change the RF (x0 is hardwired zero). Both REF and RTL now **count** them in the write stream so retirement counts align.
+
+- **REF:** `rf_write_txn.valid = reg_wr_en && run && !rst` (no `rd != 0` filter). REF still does not update `regfile[0]`; it only reports (rd, data) for the checker.
+- **Checker:** Captures every `ref_rf_write.valid` and every `rtl_rf_wr_en` (including rd=0). End-of-test comparison is still (rd, data); x0 entries are (0, data) and must match on both sides.
+
+So “RF write” in the summary means “retirement that has a register write”, including writes to x0.

--- a/verif/rv32i_ref/tb/rv32i_ref.sv
+++ b/verif/rv32i_ref/tb/rv32i_ref.sv
@@ -489,7 +489,7 @@ module rv32i_ref
     // Transaction Outputs (combinational from current state)
     //=======================================================
     always_comb begin
-        rf_write_txn.valid      = reg_wr_en && (rd != 5'd0) && run && !rst;
+        rf_write_txn.valid      = reg_wr_en && run && !rst;  // include x0 writes (retired, no RF effect)
         rf_write_txn.rd         = rd;
         rf_write_txn.data       = reg_wr_data;
         rf_write_txn.pc         = pc;

--- a/verif/rv32i_ref/tb/rv_cpu_checker.sv
+++ b/verif/rv32i_ref/tb/rv_cpu_checker.sv
@@ -1,19 +1,25 @@
 //----------------------------------------------------------
 // rv_cpu_checker - Compare RTL vs Reference Model
 //----------------------------------------------------------
-// Free-running DFF samples REF output every cycle (alignment).
-// Combinational compare with RTL Q104H.
-// Linear code: fully verified. Branch alignment: WIP.
+// Records all RF writes (pc, rd, data) from REF and RTL in arrays.
+// Stops recording when ebreak_detected; anything after ebreak is ignored.
+// At end of test (do_final_compare=1) compares the two arrays (pc + rd + data).
+// No live alignment: if RTL is correct, arrays match.
 //----------------------------------------------------------
 
 `include "dff_macros.svh"
 
 module rv_cpu_checker
     import rv32i_ref_pkg::*;
-(
+#(
+    parameter int MAX_RF_WRITES = 16384,
+    parameter int MAX_DUMP_MISMATCHES = 25
+)(
     input logic clk,
     input logic rst,
     input logic run,
+    input logic do_final_compare,
+    input logic ebreak_detected,   // stop recording once ebreak is seen (REF or EOT)
 
     input t_rf_write_txn   ref_rf_write,
     input t_dmem_write_txn ref_dmem_write,
@@ -21,7 +27,7 @@ module rv_cpu_checker
     input logic        rtl_rf_wr_en,
     input logic [4:0]  rtl_rf_rd,
     input logic [31:0] rtl_rf_wr_data,
-    input logic [31:0] rtl_pc_Q102H,
+    input logic [31:0] rtl_pc_Q104H,
 
     input logic        rtl_dmem_wr_en,
     input logic [31:0] rtl_dmem_addr,
@@ -32,66 +38,134 @@ module rv_cpu_checker
     output int         rf_write_count,
     output int         rf_error_count,
     output int         dmem_write_count,
-    output int         dmem_error_count
+    output int         dmem_error_count,
+
+    output int         final_ref_count,
+    output int         final_rtl_count,
+    output int         final_rf_error_count
 );
 
-    // Free-running alignment DFFs
-    t_rf_write_txn ref_rf_q;
-    logic          run_q;
-    `DFF(ref_rf_q, ref_rf_write, clk)
-    `DFF_RST(run_q, run, clk, rst)
+    //----------------------------------------------------------
+    // Capture arrays (pc, rd, data for each RF write)
+    //----------------------------------------------------------
+    logic [31:0] ref_pc   [0:MAX_RF_WRITES-1];
+    logic [4:0]  ref_rd   [0:MAX_RF_WRITES-1];
+    logic [31:0] ref_data [0:MAX_RF_WRITES-1];
+    logic [31:0] rtl_pc   [0:MAX_RF_WRITES-1];
+    logic [4:0]  rtl_rd   [0:MAX_RF_WRITES-1];
+    logic [31:0] rtl_data [0:MAX_RF_WRITES-1];
 
-    // Combinational mismatch detect
-    logic rf_mismatch;
-    logic compare_en;
-    assign compare_en = run_q && run && !rst;
+    int ref_count;
+    int rtl_count;
+
+    // Stop recording once ebreak is detected (latch so we never capture after)
+    logic ebreak_seen;
+    logic next_ebreak_seen;
+    assign next_ebreak_seen = ebreak_seen || ebreak_detected;
+    `DFF_RST(ebreak_seen, next_ebreak_seen, clk, rst)
+
+    // Next state for counts (combinational)
+    int next_ref_count;
+    int next_rtl_count;
+    logic ref_capture_en;
+    logic rtl_capture_en;
+    logic stop_capture;  // high from the cycle ebreak is detected (no further captures)
+    assign stop_capture = ebreak_seen || ebreak_detected;
+    assign ref_capture_en = !rst && !stop_capture && ref_rf_write.valid;   // stop at ebreak
+    assign rtl_capture_en = !rst && !stop_capture && rtl_rf_wr_en;         // stop at ebreak
+    assign next_ref_count = ref_count + (ref_capture_en ? 1 : 0);
+    assign next_rtl_count = rtl_count + (rtl_capture_en ? 1 : 0);
+
+    `DFF_RST_VAL(ref_count, next_ref_count, clk, rst, 0)
+    `DFF_RST_VAL(rtl_count, next_rtl_count, clk, rst, 0)
+
+    // Next-state for capture arrays (combinational)
+    logic [31:0] next_ref_pc   [0:MAX_RF_WRITES-1];
+    logic [4:0]  next_ref_rd   [0:MAX_RF_WRITES-1];
+    logic [31:0] next_ref_data [0:MAX_RF_WRITES-1];
+    logic [31:0] next_rtl_pc   [0:MAX_RF_WRITES-1];
+    logic [4:0]  next_rtl_rd   [0:MAX_RF_WRITES-1];
+    logic [31:0] next_rtl_data [0:MAX_RF_WRITES-1];
 
     always_comb begin
-        rf_mismatch = 1'b0;
-        if (compare_en) begin
-            if      (ref_rf_q.valid && rtl_rf_wr_en)  rf_mismatch = (ref_rf_q.rd !== rtl_rf_rd) || (ref_rf_q.data !== rtl_rf_wr_data);
-            else if (ref_rf_q.valid && !rtl_rf_wr_en) rf_mismatch = (ref_rf_q.rd != 5'd0);
-            else if (!ref_rf_q.valid && rtl_rf_wr_en)  rf_mismatch = (rtl_rf_rd != 5'd0);
+        for (int i = 0; i < MAX_RF_WRITES; i++) begin
+            next_ref_pc[i]   = (ref_capture_en && i == ref_count)   ? ref_rf_write.pc     : ref_pc[i];
+            next_ref_rd[i]   = (ref_capture_en && i == ref_count)   ? ref_rf_write.rd     : ref_rd[i];
+            next_ref_data[i] = (ref_capture_en && i == ref_count)   ? ref_rf_write.data   : ref_data[i];
+            next_rtl_pc[i]   = (rtl_capture_en && i == rtl_count)   ? rtl_pc_Q104H        : rtl_pc[i];
+            next_rtl_rd[i]   = (rtl_capture_en && i == rtl_count)   ? rtl_rf_rd           : rtl_rd[i];
+            next_rtl_data[i] = (rtl_capture_en && i == rtl_count)   ? rtl_rf_wr_data     : rtl_data[i];
         end
     end
 
-    // Counter state and next-state
-    int cycle_count;
-    int next_rf_write_count;
-    int next_rf_error_count;
-    int next_cycle_count;
-    logic next_check_error;
+    `DFF_MEM(ref_pc,   next_ref_pc,   clk, 1'b1)
+    `DFF_MEM(ref_rd,   next_ref_rd,   clk, 1'b1)
+    `DFF_MEM(ref_data, next_ref_data, clk, 1'b1)
+    `DFF_MEM(rtl_pc,   next_rtl_pc,   clk, 1'b1)
+    `DFF_MEM(rtl_rd,   next_rtl_rd,   clk, 1'b1)
+    `DFF_MEM(rtl_data, next_rtl_data, clk, 1'b1)
 
+    //----------------------------------------------------------
+    // Final comparison when do_final_compare is asserted
+    //----------------------------------------------------------
+    int compare_errors;
     always_comb begin
-        next_rf_write_count = rf_write_count;
-        next_rf_error_count = rf_error_count;
-        next_cycle_count    = cycle_count + 1;
-        next_check_error    = check_error;
-        if (compare_en) begin
-            if (rtl_rf_wr_en && rtl_rf_rd != 5'd0)
-                next_rf_write_count = rf_write_count + 1;
-            if (rf_mismatch)  begin
-                next_rf_error_count = rf_error_count + 1;
-                next_check_error    = 1'b1;
+        compare_errors = 0;
+        if (do_final_compare) begin
+            for (int i = 0; i < ref_count && i < rtl_count; i++)
+                if (ref_pc[i] !== rtl_pc[i] || ref_rd[i] !== rtl_rd[i] || ref_data[i] !== rtl_data[i])
+                    compare_errors++;
+            if (ref_count != rtl_count)
+                compare_errors += (ref_count > rtl_count) ? (ref_count - rtl_count) : (rtl_count - ref_count);
+        end
+    end
+
+    assign final_ref_count    = ref_count;
+    assign final_rtl_count    = rtl_count;
+    assign final_rf_error_count = compare_errors;
+
+    // One-shot dump of first N mismatches at EOT (verification only)
+    logic dumped;
+    always_ff @(posedge clk) begin
+        if (rst)
+            dumped <= 1'b0;
+        else if (do_final_compare && !dumped) begin
+            dumped <= 1'b1;
+            begin
+                automatic int dc = 0;
+                automatic int max_i = (ref_count > rtl_count) ? ref_count : rtl_count;
+                $display("  --- First 3 entries (REF vs RTL) ---");
+                for (int i = 0; i < 3 && i < ref_count && i < rtl_count; i++)
+                    $display("  [%0d] REF pc=0x%08h x%0d=0x%08h   RTL pc=0x%08h x%0d=0x%08h  %s",
+                        i, ref_pc[i], ref_rd[i], ref_data[i], rtl_pc[i], rtl_rd[i], rtl_data[i],
+                        (ref_pc[i]==rtl_pc[i]&&ref_rd[i]==rtl_rd[i]&&ref_data[i]==rtl_data[i]) ? "OK" : "MISMATCH");
+                $display("  --- RF write mismatch dump (first %0d) ---", MAX_DUMP_MISMATCHES);
+                dc = 0;
+                for (int i = 0; i < max_i && dc < MAX_DUMP_MISMATCHES; i++)
+                    if (i >= ref_count || i >= rtl_count || ref_pc[i] !== rtl_pc[i] || ref_rd[i] !== rtl_rd[i] || ref_data[i] !== rtl_data[i]) begin
+                        if (i >= ref_count)
+                            $display("  [%0d] REF (none)                    RTL pc=0x%08h x%0d=0x%08h  (RTL extra)", i, rtl_pc[i], rtl_rd[i], rtl_data[i]);
+                        else if (i >= rtl_count)
+                            $display("  [%0d] REF pc=0x%08h x%0d=0x%08h  RTL (none)  (REF extra)", i, ref_pc[i], ref_rd[i], ref_data[i]);
+                        else
+                            $display("  [%0d] REF pc=0x%08h x%0d=0x%08h   RTL pc=0x%08h x%0d=0x%08h", i, ref_pc[i], ref_rd[i], ref_data[i], rtl_pc[i], rtl_rd[i], rtl_data[i]);
+                        dc++;
+                    end
+                if (ref_count != rtl_count)
+                    $display("  (length mismatch: REF=%0d  RTL=%0d; %0d extra from %s)",
+                        ref_count, rtl_count,
+                        (ref_count > rtl_count) ? ref_count - rtl_count : rtl_count - ref_count,
+                        (ref_count > rtl_count) ? "REF" : "RTL");
+                $display("  --- end mismatch dump ---");
             end
         end
     end
 
-    // Registered counters
-    `DFF_RST_VAL(cycle_count,      next_cycle_count,    clk, rst, 0)
-    `DFF_RST_VAL(rf_write_count,   next_rf_write_count, clk, rst, 0)
-    `DFF_RST_VAL(rf_error_count,   next_rf_error_count, clk, rst, 0)
-    `DFF_RST_VAL(dmem_write_count, dmem_write_count,    clk, rst, 0)
-    `DFF_RST_VAL(dmem_error_count, dmem_error_count,    clk, rst, 0)
-    `DFF_RST_VAL(check_error,      next_check_error,    clk, rst, 1'b0)
-
-    // Error reporting (procedural — verification only)
-    always @(posedge clk) begin
-        if (!rst && compare_en && rf_mismatch) begin
-            $display("ERROR [RF] @%0t (C=%0d) pc=0x%08h %s: REF x%0d=0x%08h  RTL x%0d=0x%08h",
-                $time, cycle_count, ref_rf_q.pc, ref_rf_q.instr_type.name(),
-                ref_rf_q.rd, ref_rf_q.data, rtl_rf_rd, rtl_rf_wr_data);
-        end
-    end
+    // Legacy outputs for TB summary (use final counts at eot)
+    assign rf_write_count   = rtl_count;
+    assign rf_error_count   = final_rf_error_count;
+    assign dmem_write_count = 0;
+    assign dmem_error_count = 0;
+    assign check_error      = do_final_compare && (final_rf_error_count != 0);
 
 endmodule

--- a/verif/rv_cpu/rv_cpu_tb.sv
+++ b/verif/rv_cpu/rv_cpu_tb.sv
@@ -63,6 +63,10 @@ module rv_cpu_tb;
     int   rf_error_count;
     int   dmem_write_count;
     int   dmem_error_count;
+    logic do_final_compare;
+    int   final_ref_count;
+    int   final_rtl_count;
+    int   final_rf_error_count;
 
     //----------------------------------------------------------
     // Instruction Decoder Function (for trackers)
@@ -196,33 +200,32 @@ module rv_cpu_tb;
     //----------------------------------------------------------
     // Checker - Compare RTL vs Reference
     //----------------------------------------------------------
+    initial do_final_compare = 1'b0;
+
     rv_cpu_checker u_checker (
-        .clk              (clk),
-        .rst              (rst),
-        .run              (run),
-        
-        // Reference model transactions
-        .ref_rf_write     (ref_rf_write),
-        .ref_dmem_write   (ref_dmem_write),
-        
-        // RTL RF write signals (Q104H)
-        .rtl_rf_wr_en     (dut.wb_ctrl.reg_write_en_Q104H),
-        .rtl_rf_rd        (dut.wb_ctrl.reg_dst_Q104H),
-        .rtl_rf_wr_data   (dut.wb_data_Q104H),
-        .rtl_pc_Q102H     (dut.pc_Q102H),
-        
-        // RTL DMEM write signals (Q103H)
-        .rtl_dmem_wr_en   (dut.core2dmem_req_Q103H.wr_en),
-        .rtl_dmem_addr    (dut.alu_out_Q103H),
-        .rtl_dmem_wr_data (dut.dmem_wr_data_Q103H),
-        .rtl_dmem_byte_en (dut.core2dmem_req_Q103H.byte_en),
-        
-        // Status outputs
-        .check_error      (check_error),
-        .rf_write_count   (rf_write_count),
-        .rf_error_count   (rf_error_count),
-        .dmem_write_count (dmem_write_count),
-        .dmem_error_count (dmem_error_count)
+        .clk                (clk),
+        .rst                (rst),
+        .run                (run),
+        .do_final_compare   (do_final_compare),
+        .ebreak_detected    (u_ref.ebreak_called),
+        .ref_rf_write       (ref_rf_write),
+        .ref_dmem_write     (ref_dmem_write),
+        .rtl_rf_wr_en       (dut.wb_ctrl.reg_write_en_Q104H),
+        .rtl_rf_rd          (dut.wb_ctrl.reg_dst_Q104H),
+        .rtl_rf_wr_data     (dut.wb_data_Q104H),
+        .rtl_pc_Q104H       (dut.pc_Q102H), // TEMP: use execute-stage PC until ctrl-based retire PC is added
+        .rtl_dmem_wr_en     (dut.core2dmem_req_Q103H.wr_en),
+        .rtl_dmem_addr      (dut.alu_out_Q103H),
+        .rtl_dmem_wr_data   (dut.dmem_wr_data_Q103H),
+        .rtl_dmem_byte_en   (dut.core2dmem_req_Q103H.byte_en),
+        .check_error        (check_error),
+        .rf_write_count     (rf_write_count),
+        .rf_error_count     (rf_error_count),
+        .dmem_write_count   (dmem_write_count),
+        .dmem_error_count   (dmem_error_count),
+        .final_ref_count   (final_ref_count),
+        .final_rtl_count   (final_rtl_count),
+        .final_rf_error_count (final_rf_error_count)
     );
 
     //----------------------------------------------------------
@@ -293,19 +296,22 @@ module rv_cpu_tb;
         if (log_mem != 0) $fclose(log_mem);
         if (log_wb != 0)  $fclose(log_wb);
         
-        // Print summary
+        // Trigger final array compare (REF vs RTL RF writes)
+        do_final_compare = 1'b1;
+        #(CLK_PERIOD * 2);
+        
+        // Print summary (array comparison at end of test)
         $display("\n");
         $display("========================================");
         $display("        END OF TEST: %s", reason);
         $display("========================================");
         $display("  Total Cycles:      %0d", cycle_count);
-        $display("  RF Writes:         %0d", rf_write_count);
-        $display("  RF Errors:         %0d", rf_error_count);
-        $display("  DMEM Writes:       %0d", dmem_write_count);
-        $display("  DMEM Errors:       %0d", dmem_error_count);
+        $display("  REF RF writes:     %0d", final_ref_count);
+        $display("  RTL RF writes:     %0d", final_rtl_count);
+        $display("  RF mismatches:     %0d", final_rf_error_count);
         $display("----------------------------------------");
         
-        if (rf_error_count == 0 && dmem_error_count == 0) begin
+        if (final_rf_error_count == 0) begin
             $display("  STATUS: PASS");
         end else begin
             $display("  STATUS: FAIL");


### PR DESCRIPTION
- rv_cpu_checker: record (pc, rd, data) in arrays; EOT compare; stop capture when ebreak_detected
- rv32i_ref: include x0 writes in rf_write_txn (retired but no RF effect)
- rv_cpu_tb: wire ebreak_detected, do_final_compare; print REF/RTL counts and mismatches
- docs: EBREAK_MISMATCH_ANALYSIS (RTL duplicate retirements), RTL_FIXES_REVIEW

No RTL source changes.

Made-with: Cursor